### PR TITLE
URLをherokuに差し替えた

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_BASE_URL="http://localhost:3000/api/v1"
+NEXT_PUBLIC_BASE_URL="https://payreco.herokuapp.com/api/v1"

--- a/src/api/custom-instance.ts
+++ b/src/api/custom-instance.ts
@@ -3,6 +3,10 @@ import { auth } from "auth/firebase";
 
 export const AXIOS_INSTANCE = Axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_URL,
+  headers: {
+    "Content-Type": "application/json",
+    "X-Requested-With": "XMLHttpRequest",
+  },
 });
 
 AXIOS_INSTANCE.interceptors.request.use(async function (config) {


### PR DESCRIPTION
fly.ioでヘッダートークンを付けるとレスポンスが返ってこないためherokuに差し替えました。

※今後再変更する可能性あり