### PR TITLE
論理削除済みの勤務先をスケジュールには残しつつ勤務先リストから見られないようにした

### DIFF
--- a/src/components/organisms/CompanyList.tsx
+++ b/src/components/organisms/CompanyList.tsx
@@ -21,9 +21,12 @@ function CompapyList() {
             <p>Loading</p>
           ) : (
             <ul>
-              {data?.map((company) => (
-                <CompanyDetails key={company.id} company={company} />
-              ))}
+              {data?.map(
+                (company) =>
+                  company.deleted_at === null && (
+                    <CompanyDetails key={company.id} company={company} />
+                  )
+              )}
             </ul>
           )}
           <Button text="新規登録" onClick={() => setCompanyForm(true)} />

--- a/src/components/organisms/WorkList.tsx
+++ b/src/components/organisms/WorkList.tsx
@@ -52,16 +52,19 @@ function WorkList({ selectedDay, selectedDayWorks }: Props) {
       ) : (
         <div className="mb-10">
           {data && data.length > 0 ? (
-            data.map((company) => (
-              <Button
-                key={company.id}
-                text={company.name}
-                onClick={() => {
-                  setWorkForm(true);
-                  setSelectedCompany(company);
-                }}
-              />
-            ))
+            data.map(
+              (company) =>
+                company.deleted_at === null && (
+                  <Button
+                    key={company.id}
+                    text={company.name}
+                    onClick={() => {
+                      setWorkForm(true);
+                      setSelectedCompany(company);
+                    }}
+                  />
+                )
+            )
           ) : (
             <p>
               勤務先の登録がありません。勤務先を登録をすると予定を追加できるようになります。


### PR DESCRIPTION
## 🥷変更前
論理削除した勤務先データを全てのコンポーネントから見られないようにしていました。

## 🥷変更後
論理削除した勤務先データをスケジュール一覧には残しつつ、勤務先一覧では見られないようにしました。