### PR TITLE
給料計算機能関連の向上・バグ修正

### DIFF
--- a/src/components/atoms/Chart.tsx
+++ b/src/components/atoms/Chart.tsx
@@ -21,10 +21,12 @@ function Chart({ target, earnedIncome, expectedIncome }: Props) {
         <div
           className="absolute h-6 text-center bg-stone-500 rounded-full"
           style={{ width: `${showRate(achievementRate)}%` }}
-        >
-          {showRate(achievementRate)}%
-        </div>
+        ></div>
       </div>
+      <p className="text-xs">
+        現時点: {showRate(achievementRate)}% 見込み含め:{" "}
+        {showRate(expectedAchievementRate)}%
+      </p>
     </div>
   );
 }

--- a/src/components/molecules/Annualncome.tsx
+++ b/src/components/molecules/Annualncome.tsx
@@ -5,11 +5,11 @@ type Props = { incomeList?: { [key: string]: [[Date, number]] } };
 function AnnualIncome({ incomeList }: Props) {
   const thisYear = new Date().getFullYear();
   const numArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
-  const thisYearMonths = numArray.map((month) =>
+  const monthsOfThisYear = numArray.map((month) =>
     Number(thisYear + ("0" + month).slice(-2))
   );
 
-  const incomeListByMonth = thisYearMonths.map(
+  const incomeListByMonth = monthsOfThisYear.map(
     (month) =>
       (incomeList &&
         incomeList[month] &&

--- a/src/components/molecules/Annualncome.tsx
+++ b/src/components/molecules/Annualncome.tsx
@@ -2,19 +2,18 @@ import Heading from "components/atoms/Heading";
 
 type Props = {
   incomeList?: { [key: string]: [[Date, number]] };
-  loading: boolean;
 };
 
-function AnnualIncome({ incomeList, loading }: Props) {
-  const year = new Date().getFullYear();
-  const months = Array(12)
+function AnnualIncome({ incomeList }: Props) {
+  const thisYear = new Date().getFullYear();
+  const numArray = Array(12)
     .fill(0)
     .map((_, i) => i + 1);
-  const yearAndMonths = months.map((month) =>
-    Number(year + ("0" + month).slice(-2))
+  const thisYearMonths = numArray.map((month) =>
+    Number(thisYear + ("0" + month).slice(-2))
   );
 
-  const incomeListByMonth = yearAndMonths.map(
+  const incomeListByMonth = thisYearMonths.map(
     (month) =>
       (incomeList &&
         incomeList[month] &&
@@ -30,9 +29,7 @@ function AnnualIncome({ incomeList, loading }: Props) {
   return (
     <div>
       <Heading text="年間の給料" />
-      {loading ? (
-        <p>Laoding</p>
-      ) : (
+      {incomeList && isFinite(annualTotalIncome) ? (
         <>
           <ul>
             {incomeListByMonth.map((income, idx) => (
@@ -43,6 +40,8 @@ function AnnualIncome({ incomeList, loading }: Props) {
           </ul>
           <p className="mt-10">合計: {annualTotalIncome.toLocaleString()}円</p>
         </>
+      ) : (
+        <p>Laoding</p>
       )}
     </div>
   );

--- a/src/components/molecules/Annualncome.tsx
+++ b/src/components/molecules/Annualncome.tsx
@@ -1,14 +1,10 @@
 import Heading from "components/atoms/Heading";
 
-type Props = {
-  incomeList?: { [key: string]: [[Date, number]] };
-};
+type Props = { incomeList?: { [key: string]: [[Date, number]] } };
 
 function AnnualIncome({ incomeList }: Props) {
   const thisYear = new Date().getFullYear();
-  const numArray = Array(12)
-    .fill(0)
-    .map((_, i) => i + 1);
+  const numArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12];
   const thisYearMonths = numArray.map((month) =>
     Number(thisYear + ("0" + month).slice(-2))
   );

--- a/src/components/molecules/MonthlyIncome.tsx
+++ b/src/components/molecules/MonthlyIncome.tsx
@@ -13,11 +13,11 @@ function MonthlyIncome({ income, loading }: Props) {
   const { data } = useGetUsersUserId();
 
   const totalIncome = income?.reduce((sum, array) => sum + array[1], 0) || 0;
-  const pastWorksPay = income?.filter((data) =>
+  const payOfPastWorks = income?.filter((data) =>
     isPast(parseISO(String(data[0])))
   );
   const earnedIncome =
-    pastWorksPay?.reduce((sum, array) => sum + array[1], 0) || 0;
+    payOfPastWorks?.reduce((sum, array) => sum + array[1], 0) || 0;
   const expectedIncome = totalIncome - earnedIncome;
 
   return (

--- a/src/components/molecules/MonthlyIncome.tsx
+++ b/src/components/molecules/MonthlyIncome.tsx
@@ -4,9 +4,12 @@ import TargetAmountForm from "components/organisms/TagertAmountForm";
 import { useGetUsersUserId } from "api/users/users";
 import { isPast, parseISO } from "date-fns";
 
-type Props = { income?: [[Date, number]] };
+type Props = {
+  income?: [[Date, number]];
+  loading: boolean;
+};
 
-function MonthlyIncome({ income }: Props) {
+function MonthlyIncome({ income, loading }: Props) {
   const { data } = useGetUsersUserId();
 
   const totalIncome = income?.reduce((sum, array) => sum + array[1], 0) || 0;
@@ -20,7 +23,7 @@ function MonthlyIncome({ income }: Props) {
   return (
     <>
       <Heading text="今月の給料" />
-      {expectedIncome ? (
+      {!loading && isFinite(totalIncome) ? (
         <div>
           <ul>
             <li className="mb-2">現在: {earnedIncome.toLocaleString()}円</li>

--- a/src/components/molecules/MonthlyIncome.tsx
+++ b/src/components/molecules/MonthlyIncome.tsx
@@ -4,9 +4,7 @@ import TargetAmountForm from "components/organisms/TagertAmountForm";
 import { useGetUsersUserId } from "api/users/users";
 import { isPast, parseISO } from "date-fns";
 
-type Props = {
-  income?: [[Date, number]];
-};
+type Props = { income?: [[Date, number]] };
 
 function MonthlyIncome({ income }: Props) {
   const { data } = useGetUsersUserId();
@@ -22,9 +20,7 @@ function MonthlyIncome({ income }: Props) {
   return (
     <>
       <Heading text="今月の給料" />
-      {!expectedIncome ? (
-        <p>Loading</p>
-      ) : (
+      {expectedIncome ? (
         <div>
           <ul>
             <li className="mb-2">現在: {earnedIncome.toLocaleString()}円</li>
@@ -42,6 +38,8 @@ function MonthlyIncome({ income }: Props) {
           )}
           {data && <TargetAmountForm user={data} />}
         </div>
+      ) : (
+        <p>Loading</p>
       )}
     </>
   );

--- a/src/components/molecules/MonthlyIncome.tsx
+++ b/src/components/molecules/MonthlyIncome.tsx
@@ -1,15 +1,16 @@
-import { useGetUsersUserId } from "api/users/users";
 import Chart from "components/atoms/Chart";
 import Heading from "components/atoms/Heading";
 import TargetAmountForm from "components/organisms/TagertAmountForm";
+import { useGetUsersUserId } from "api/users/users";
 import { isPast, parseISO } from "date-fns";
 
 type Props = {
   income?: [[Date, number]];
-  loading: boolean;
 };
 
-function MonthlyIncome({ income, loading }: Props) {
+function MonthlyIncome({ income }: Props) {
+  const { data } = useGetUsersUserId();
+
   const totalIncome = income?.reduce((sum, array) => sum + array[1], 0) || 0;
   const pastWorksPay = income?.filter((data) =>
     isPast(parseISO(String(data[0])))
@@ -18,12 +19,10 @@ function MonthlyIncome({ income, loading }: Props) {
     pastWorksPay?.reduce((sum, array) => sum + array[1], 0) || 0;
   const expectedIncome = totalIncome - earnedIncome;
 
-  const { data } = useGetUsersUserId();
-
   return (
     <>
       <Heading text="今月の給料" />
-      {loading ? (
+      {!expectedIncome ? (
         <p>Loading</p>
       ) : (
         <div>

--- a/src/components/organisms/IncomeList.tsx
+++ b/src/components/organisms/IncomeList.tsx
@@ -37,7 +37,7 @@ function IncomeList() {
   const thisMonth = Number(
     new Date().getFullYear() + ("0" + (new Date().getMonth() + 1)).slice(-2)
   );
-  const thisMonthIncome = incomeListByMonth && incomeListByMonth[thisMonth];
+  const incomeOfThisMonth = incomeListByMonth && incomeListByMonth[thisMonth];
 
   return (
     <div className="pt-5">
@@ -63,7 +63,7 @@ function IncomeList() {
         <div className="md:grid md:grid-cols-2 md:divide-x md:divide-gray-200">
           <div className="md:pr-14">
             <div className={!monthlyMode ? "hidden md:inline-block" : ""}>
-              <MonthlyIncome income={thisMonthIncome} loading={isLoading} />
+              <MonthlyIncome income={incomeOfThisMonth} loading={isLoading} />
             </div>
           </div>
           <div

--- a/src/components/organisms/IncomeList.tsx
+++ b/src/components/organisms/IncomeList.tsx
@@ -25,10 +25,10 @@ function IncomeList() {
     )!;
     const rate = findCurrencyRate(work, company, exchangeRates!);
 
-    const convertedPayToJPY = Math.floor(work.pay_amount / rate);
+    const payAmountWithJPY = Math.floor(work.pay_amount / rate);
     (map[monthOfWorks] = map[monthOfWorks] || []).push([
       work.date,
-      convertedPayToJPY,
+      payAmountWithJPY,
     ]);
     return map;
   }, {} as { [key: string]: [[Date, number]] });

--- a/src/components/organisms/IncomeList.tsx
+++ b/src/components/organisms/IncomeList.tsx
@@ -8,7 +8,7 @@ import { useGetExchangeRates } from "api/exchange-rates/exchange-rates";
 import { findCurrencyRate } from "utils/find-currency-rate";
 
 function IncomeList() {
-  const { data: works } = useGetWorks();
+  const { data: works, isLoading } = useGetWorks();
   const { data: companies } = useGetCompanies();
   const { data: exchangeRates } = useGetExchangeRates();
 
@@ -63,7 +63,7 @@ function IncomeList() {
         <div className="md:grid md:grid-cols-2 md:divide-x md:divide-gray-200">
           <div className="md:pr-14">
             <div className={!monthlyMode ? "hidden md:inline-block" : ""}>
-              <MonthlyIncome income={thisMonthIncome} />
+              <MonthlyIncome income={thisMonthIncome} loading={isLoading} />
             </div>
           </div>
           <div

--- a/src/components/organisms/IncomeList.tsx
+++ b/src/components/organisms/IncomeList.tsx
@@ -8,7 +8,7 @@ import { useGetExchangeRates } from "api/exchange-rates/exchange-rates";
 import { findCurrencyRate } from "utils/find-currency-rate";
 
 function IncomeList() {
-  const { data: works, isLoading } = useGetWorks();
+  const { data: works } = useGetWorks();
   const { data: companies } = useGetCompanies();
   const { data: exchangeRates } = useGetExchangeRates();
 
@@ -23,8 +23,9 @@ function IncomeList() {
     const company = companies?.find(
       (company): boolean => company.id === work.company_id
     )!;
-    const rate = findCurrencyRate(work, company, exchangeRates!);
-
+    const rate = exchangeRates
+      ? findCurrencyRate(work, company, exchangeRates)
+      : 0;
     const payAmountWithJPY = Math.floor(work.pay_amount / rate);
     (map[monthOfWorks] = map[monthOfWorks] || []).push([
       work.date,
@@ -62,7 +63,7 @@ function IncomeList() {
         <div className="md:grid md:grid-cols-2 md:divide-x md:divide-gray-200">
           <div className="md:pr-14">
             <div className={!monthlyMode ? "hidden md:inline-block" : ""}>
-              <MonthlyIncome income={thisMonthIncome} loading={isLoading} />
+              <MonthlyIncome income={thisMonthIncome} />
             </div>
           </div>
           <div
@@ -70,7 +71,7 @@ function IncomeList() {
               monthlyMode ? "hidden md:inline-block md:pl-14" : "mb-8 md:pl-14"
             }
           >
-            <AnnualIncome incomeList={incomeListByMonth} loading={isLoading} />
+            <AnnualIncome incomeList={incomeListByMonth} />
           </div>
         </div>
       </div>

--- a/src/components/organisms/WorkDetails.tsx
+++ b/src/components/organisms/WorkDetails.tsx
@@ -1,25 +1,29 @@
-import { format, parseISO } from "date-fns";
-import { Company, Work } from "api/model";
-import { useState } from "react";
 import WorkForm from "components/organisms/WorkForm";
 import Button from "components/atoms/Button";
 import DeleteConfirmation from "./DeleteConfirmation";
 import Modal from "./Modal";
+import { format, parseISO } from "date-fns";
+import { Company, Work } from "api/model";
+import { useState } from "react";
+import { useGetExchangeRates } from "api/exchange-rates/exchange-rates";
+import { findCurrencyRate } from "utils/find-currency-rate";
 
 type Props = {
   work: Work;
   selectedDay: Date;
-  company?: Company;
+  company: Company;
 };
 
 function WorkDetails({ work, selectedDay, company }: Props) {
   const [workForm, setWorkForm] = useState<boolean>(false);
   const [deleteConfirmation, setDeleteConfirmation] = useState<boolean>(false);
+  const { data } = useGetExchangeRates();
   const startingTime = parseISO(`${work.starting_time}`);
   const endingTime = parseISO(`${work.ending_time}`);
-  const hasBreak = work.break_time !== null && work.break_time > 0
-  const hourOfBreak = work.break_time ? Math.floor(work.break_time / 60) : 0
-  const minuteOfBreak = work.break_time ? work.break_time % 60 : 0
+  const hasBreak = work.break_time !== null && work.break_time > 0;
+  const hourOfBreak = work.break_time ? Math.floor(work.break_time / 60) : 0;
+  const minuteOfBreak = work.break_time ? work.break_time % 60 : 0;
+  const rate = findCurrencyRate(work, company, data!);
 
   return (
     <li className="flex items-center px-4 py-2 space-x-4 group rounded-xl focus-within:bg-gray-100 hover:bg-gray-100">
@@ -30,15 +34,15 @@ function WorkDetails({ work, selectedDay, company }: Props) {
               endingTime,
               "h:mm a"
             )}`}
-          {hasBreak && ' 休憩:'}
+          {hasBreak && " 休憩:"}
           {hourOfBreak > 0 && `${hourOfBreak}時間`}
           {minuteOfBreak > 0 && `${minuteOfBreak}分`}
         </p>
-        <p className="text-gray-900">{company?.name}</p>
+        <p className="text-gray-900">{company.name}</p>
         <p>
           {`合計勤務: ${work.working_hours}時間 `}
-          {`給料: ${work.pay_amount}`}
-          {company?.currency_type}
+          {`給料: ${work.pay_amount}${company.currency_type}`}
+          {rate && ` (${Math.floor(work.pay_amount / rate)}円)`}
         </p>
         <p>{work.memo && `メモ: ${work.memo}`}</p>
       </div>

--- a/src/components/organisms/WorkDetails.tsx
+++ b/src/components/organisms/WorkDetails.tsx
@@ -13,10 +13,13 @@ type Props = {
 };
 
 function WorkDetails({ work, selectedDay, company }: Props) {
-  const startingTime = parseISO(`${work.starting_time}`);
-  const endingTime = parseISO(`${work.ending_time}`);
   const [workForm, setWorkForm] = useState<boolean>(false);
   const [deleteConfirmation, setDeleteConfirmation] = useState<boolean>(false);
+  const startingTime = parseISO(`${work.starting_time}`);
+  const endingTime = parseISO(`${work.ending_time}`);
+  const hasBreak = work.break_time !== null && work.break_time > 0
+  const hourOfBreak = work.break_time ? Math.floor(work.break_time / 60) : 0
+  const minuteOfBreak = work.break_time ? work.break_time % 60 : 0
 
   return (
     <li className="flex items-center px-4 py-2 space-x-4 group rounded-xl focus-within:bg-gray-100 hover:bg-gray-100">
@@ -27,11 +30,9 @@ function WorkDetails({ work, selectedDay, company }: Props) {
               endingTime,
               "h:mm a"
             )}`}
-          {work.break_time && work.break_time > 0
-            ? ` (休憩: ${Math.floor(work.break_time / 60)}時間${
-                work.break_time % 60
-              }分)`
-            : ``}
+          {hasBreak && ' 休憩:'}
+          {hourOfBreak > 0 && `${hourOfBreak}時間`}
+          {minuteOfBreak > 0 && `${minuteOfBreak}分`}
         </p>
         <p className="text-gray-900">{company?.name}</p>
         <p>
@@ -41,11 +42,9 @@ function WorkDetails({ work, selectedDay, company }: Props) {
         </p>
         <p>{work.memo && `メモ: ${work.memo}`}</p>
       </div>
-
       <div className="flex">
         <Button text="編集" onClick={() => setWorkForm(true)} />
         <Button text="削除" onClick={() => setDeleteConfirmation(true)} />
-
         <Modal modal={workForm} setModal={setWorkForm}>
           <WorkForm
             selectedDay={selectedDay}
@@ -54,7 +53,6 @@ function WorkDetails({ work, selectedDay, company }: Props) {
             work={work}
           />
         </Modal>
-
         <Modal modal={deleteConfirmation} setModal={setDeleteConfirmation}>
           <DeleteConfirmation
             setDeleteConfirmation={setDeleteConfirmation}

--- a/src/components/organisms/WorkDetails.tsx
+++ b/src/components/organisms/WorkDetails.tsx
@@ -23,7 +23,7 @@ function WorkDetails({ work, selectedDay, company }: Props) {
   const hasBreak = work.break_time !== null && work.break_time > 0;
   const hourOfBreak = work.break_time ? Math.floor(work.break_time / 60) : 0;
   const minuteOfBreak = work.break_time ? work.break_time % 60 : 0;
-  const rate = findCurrencyRate(work, company, data!);
+  const rate = data ? findCurrencyRate(work, company, data) : 0;
 
   return (
     <li className="flex items-center px-4 py-2 space-x-4 group rounded-xl focus-within:bg-gray-100 hover:bg-gray-100">
@@ -42,7 +42,7 @@ function WorkDetails({ work, selectedDay, company }: Props) {
         <p>
           {`合計勤務: ${work.working_hours}時間 `}
           {`給料: ${work.pay_amount}${company.currency_type}`}
-          {rate && ` (${Math.floor(work.pay_amount / rate)}円)`}
+          {rate > 0 && ` (${Math.floor(work.pay_amount / rate)}円)`}
         </p>
         <p>{work.memo && `メモ: ${work.memo}`}</p>
       </div>

--- a/src/components/organisms/WorkForm.tsx
+++ b/src/components/organisms/WorkForm.tsx
@@ -10,7 +10,7 @@ import { Dispatch, SetStateAction, useState } from "react";
 
 type Props = {
   selectedDay: Date;
-  company?: Company;
+  company: Company;
   work?: Work;
   setWorkForm: Dispatch<SetStateAction<boolean>>;
 };
@@ -78,12 +78,12 @@ function WorkForm({ selectedDay, company, work, setWorkForm }: Props) {
 
   const formData = {
     date: addDays(selectedDay, 1),
-    company_id: company?.id,
+    company_id: company.id,
     starting_time: shiftMode ? startingTime : null,
     ending_time: shiftMode ? endingTime : null,
     break_time: shiftMode ? breakTime : null,
     working_hours: workingHours,
-    pay_amount: company?.wage_amount
+    pay_amount: company.wage_amount
       ? Math.round(company.wage_amount * workingHours * 100) / 100
       : payAmount,
     memo: memo !== "" ? memo : null,
@@ -122,7 +122,7 @@ function WorkForm({ selectedDay, company, work, setWorkForm }: Props) {
     <form onSubmit={handleSubmit}>
       <div>
         <label>勤務先: </label>
-        {company?.name}
+        {company.name}
       </div>
       <div className="space-x-1">
         <RadioButton
@@ -228,7 +228,7 @@ function WorkForm({ selectedDay, company, work, setWorkForm }: Props) {
       )}
       <div>
         <label>給料: </label>
-        {company?.wage_amount ? (
+        {company.wage_amount ? (
           <span>
             {Math.round(company.wage_amount * workingHours * 100) / 100}
           </span>
@@ -240,7 +240,7 @@ function WorkForm({ selectedDay, company, work, setWorkForm }: Props) {
             onChange={(e) => setPayAmount(Number(e.target.value))}
           />
         )}
-        {company?.currency_type}
+        {company.currency_type}
         {(payAmount > 999999 || payAmount < 0) && (
           <p className="text-rose-600">金額がマイナス・または大きすぎます。</p>
         )}

--- a/src/components/organisms/WorkList.tsx
+++ b/src/components/organisms/WorkList.tsx
@@ -78,15 +78,15 @@ function WorkList({ selectedDay, selectedDayWorks }: Props) {
           />
         </div>
       )}
-
-      <Modal modal={workForm} setModal={setWorkForm}>
-        <WorkForm
-          selectedDay={selectedDay}
-          company={selectedCompany}
-          setWorkForm={setWorkForm}
-        />
-      </Modal>
-
+      {selectedCompany && (
+        <Modal modal={workForm} setModal={setWorkForm}>
+          <WorkForm
+            selectedDay={selectedDay}
+            company={selectedCompany}
+            setWorkForm={setWorkForm}
+          />
+        </Modal>
+      )}
       <Modal modal={companyForm} setModal={setCompanyForm}>
         <CompanyForm setCompanyForm={setCompanyForm} />
       </Modal>

--- a/src/components/organisms/WorkList.tsx
+++ b/src/components/organisms/WorkList.tsx
@@ -19,6 +19,8 @@ function WorkList({ selectedDay, selectedDayWorks }: Props) {
   const [workForm, setWorkForm] = useState<boolean>(false);
   const [companyForm, setCompanyForm] = useState<boolean>(false);
   const [selectedCompany, setSelectedCompany] = useState<Company>();
+  const company = (work: Work) =>
+    data?.find((company): boolean => company.id === work.company_id)!;
 
   return (
     <section className="mt-12 md:mt-0 md:pl-14">
@@ -38,7 +40,7 @@ function WorkList({ selectedDay, selectedDayWorks }: Props) {
                 selectedDay={selectedDay}
                 work={work}
                 key={work.id}
-                company={data?.find((v) => v.id === work.company_id)}
+                company={company(work)}
               />
             ))
           ) : (

--- a/src/utils/find-currency-rate.ts
+++ b/src/utils/find-currency-rate.ts
@@ -16,7 +16,7 @@ export const findCurrencyRate = (
     : exchangeRates.slice(-1)[0].exchange_rate_list;
 
   const companyCurrencyRate: number =
-    rate && company.currency_type && Reflect.get(rate, company.currency_type);
+    company.currency_type && Reflect.get(rate, company.currency_type);
 
   return companyCurrencyRate;
 };

--- a/src/utils/find-currency-rate.ts
+++ b/src/utils/find-currency-rate.ts
@@ -1,0 +1,22 @@
+import { Company, ExchangeRate, Work } from "api/model";
+
+export const findCurrencyRate = (
+  work: Work,
+  company: Company,
+  exchangeRates: ExchangeRate[]
+) => {
+  const monthOfWorks = String(work.date).substring(0, 7).replace("-", "");
+
+  const selectedMonthRateData = exchangeRates.find(
+    (data) => String(data.year_and_month) === monthOfWorks
+  );
+
+  const rate = selectedMonthRateData
+    ? selectedMonthRateData.exchange_rate_list
+    : exchangeRates.slice(-1)[0].exchange_rate_list;
+
+  const companyCurrencyRate: number =
+    rate && company.currency_type && Reflect.get(rate, company.currency_type);
+
+  return companyCurrencyRate;
+};

--- a/src/utils/find-currency-rate.ts
+++ b/src/utils/find-currency-rate.ts
@@ -15,8 +15,9 @@ export const findCurrencyRate = (
     ? selectedMonthRateData.exchange_rate_list
     : exchangeRates.slice(-1)[0].exchange_rate_list;
 
-  const companyCurrencyRate: number =
-    company.currency_type && Reflect.get(rate, company.currency_type);
+  const companyCurrencyRate: number = company.currency_type
+    ? Reflect.get(rate, company.currency_type)
+    : 0;
 
   return companyCurrencyRate;
 };


### PR DESCRIPTION
* 給料計算が終わるまではローディングを表示するようにした
* 変数名の見直し
* カレンダーの勤務詳細画面では外貨の給料しか表示していなかったが日本円表示も加えた